### PR TITLE
fix the last version filter in repositories

### DIFF
--- a/ModelBundle/Repository/ContentRepository.php
+++ b/ModelBundle/Repository/ContentRepository.php
@@ -79,9 +79,9 @@ class ContentRepository extends AbstractAggregateRepository implements FieldAuto
         }
 
         $elementName = 'content';
+        $qa->sort(array('version' => 1));
         $qa->group(array(
             '_id' => array('contentId' => '$contentId'),
-            'version' => array('$max' => '$version'),
             $elementName => array('$last' => '$$ROOT')
         ));
 
@@ -230,7 +230,7 @@ class ContentRepository extends AbstractAggregateRepository implements FieldAuto
         }
 
         $elementName = 'content';
-        $qa->group($this->generateLastVersionFilter($elementName));
+        $this->generateLastVersionFilter($qa, $elementName);
 
         $qa = $this->generateFilterSort(
             $qa,
@@ -260,7 +260,7 @@ class ContentRepository extends AbstractAggregateRepository implements FieldAuto
             $qa->match($this->generateSiteIdAndNotLinkedFilter($siteId));
         }
         $elementName = 'content';
-        $qa->group($this->generateLastVersionFilter($elementName));
+        $this->generateLastVersionFilter($qa, $elementName);
 
         return $this->countDocumentAggregateQuery($qa, $elementName);
     }
@@ -275,7 +275,7 @@ class ContentRepository extends AbstractAggregateRepository implements FieldAuto
         $qa = $this->createAggregateQueryWithContentTypeFilter($contentType);
         $qa->match($this->generateDeletedFilter());
         $elementName = 'content';
-        $qa->group($this->generateLastVersionFilter($elementName));
+        $this->generateLastVersionFilter($qa, $elementName);
 
         return $this->countDocumentAggregateQuery($qa);
     }
@@ -339,17 +339,18 @@ class ContentRepository extends AbstractAggregateRepository implements FieldAuto
     }
 
     /**
+     * @param Stage  $qa
      * @param string $elementName
      *
      * @return array
      */
-    protected function generateLastVersionFilter($elementName)
+    protected function generateLastVersionFilter(Stage $qa, $elementName)
     {
-        return array(
+        $qa->sort(array('version' => 1));
+        $qa->group(array(
             '_id' => array('contentId' => '$contentId'),
-            'version' => array('$max' => '$version'),
             $elementName => array('$last' => '$$ROOT')
-        );
+        ));
     }
 
     /**

--- a/ModelBundle/Repository/ContentTypeRepository.php
+++ b/ModelBundle/Repository/ContentTypeRepository.php
@@ -8,6 +8,7 @@ use OpenOrchestra\Pagination\Configuration\PaginateFinderConfiguration;
 use OpenOrchestra\ModelInterface\Repository\ContentTypeRepositoryInterface;
 use OpenOrchestra\Pagination\MongoTrait\PaginationTrait;
 use OpenOrchestra\Repository\AbstractAggregateRepository;
+use Solution\MongoAggregation\Pipeline\Stage;
 
 /**
  * Class ContentTypeRepository
@@ -30,7 +31,7 @@ class ContentTypeRepository extends AbstractAggregateRepository implements Conte
             )
         );
         $elementName = 'contentType';
-        $qa->group($this->generateLastVersionFilter($elementName));
+        $this->generateLastVersionFilter($qa, $elementName);
 
         if ($language) {
             $qa->sort(
@@ -55,7 +56,7 @@ class ContentTypeRepository extends AbstractAggregateRepository implements Conte
         $qa = $this->generateFilter($qa, $configuration);
 
         $elementName = 'contentType';
-        $qa->group($this->generateLastVersionFilter($elementName));
+        $this->generateLastVersionFilter($qa, $elementName);
 
         $qa = $this->generateFilterSort(
             $qa,
@@ -96,7 +97,7 @@ class ContentTypeRepository extends AbstractAggregateRepository implements Conte
         $qa = $this->generateFilter($qa, $configuration);
 
         $elementName = 'contentType';
-        $qa->group($this->generateLastVersionFilter($elementName));
+        $this->generateLastVersionFilter($qa, $elementName);
 
         return $this->countDocumentAggregateQuery($qa, $elementName);
     }
@@ -108,7 +109,7 @@ class ContentTypeRepository extends AbstractAggregateRepository implements Conte
     {
         $qa = $this->createAggregateQueryNotDeletedInLastVersion();
         $elementName = 'content';
-        $qa->group($this->generateLastVersionFilter($elementName));
+        $this->generateLastVersionFilter($qa, $elementName);
 
         return $this->countDocumentAggregateQuery($qa);
     }
@@ -128,17 +129,18 @@ class ContentTypeRepository extends AbstractAggregateRepository implements Conte
     }
 
     /**
-     * @param $elementName
+     * @param Stage  $qa
+     * @param string $elementName
      *
      * @return array
      */
-    protected function generateLastVersionFilter($elementName)
+    protected function generateLastVersionFilter(Stage $qa, $elementName)
     {
-        return array(
-            '_id' => array('contentTypeId' => '$contentTypeId'),
-            'version' => array('$max' => '$version'),
+        $qa->sort(array('version' => 1));
+        $qa->group(array(
+            '_id' => array('contentId' => '$contentId'),
             $elementName => array('$last' => '$$ROOT')
-        );
+        ));
     }
 
     /**

--- a/ModelBundle/Repository/NodeRepository.php
+++ b/ModelBundle/Repository/NodeRepository.php
@@ -21,7 +21,7 @@ class NodeRepository extends AbstractAggregateRepository implements FieldAutoGen
 
     /**
      * @param string $mongoId
-     * 
+     *
      * @return \OpenOrchestra\ModelInterface\Model\NodeInterface
      */
     public function findOneById($mongoId)
@@ -302,9 +302,9 @@ class NodeRepository extends AbstractAggregateRepository implements FieldAutoGen
     protected function findLastVersion(Stage $qa)
     {
         $elementName = 'node';
+        $qa->sort(array('version' => 1));
         $qa->group(array(
             '_id' => array('nodeId' => '$nodeId'),
-            'version' => array('$max' => '$version'),
             $elementName => array('$last' => '$$ROOT')
         ));
 
@@ -512,7 +512,7 @@ class NodeRepository extends AbstractAggregateRepository implements FieldAutoGen
     /**
      * @param string $nodeType
      * @param string $siteId
-     * 
+     *
      * @return array
      */
     public function findAllNodesOfTypeInLastPublishedVersionForSite($nodeType, $siteId)


### PR DESCRIPTION
The queries for getting the latest version of a document are incorrect, as there is no explicit sorting on the collection. If the documents are not stored with increasing version in mongo, the result will be incorrect.