### PR TITLE
add type in trashItem

### DIFF
--- a/ModelBundle/Document/TrashItem.php
+++ b/ModelBundle/Document/TrashItem.php
@@ -33,6 +33,14 @@ class TrashItem implements TrashItemInterface
     protected $name;
 
     /**
+     * @var string $type
+
+     * @ODM\Field(type="string")
+     * @ORCHESTRA\Search(key="type")
+     */
+    protected $type;
+
+    /**
      * @var string
      *
      * @ODM\Field(type="string")
@@ -116,5 +124,21 @@ class TrashItem implements TrashItemInterface
     public function setName($name)
     {
         $this->name = $name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * @param string $type
+     */
+    public function setType($type)
+    {
+        $this->type = $type;
     }
 }

--- a/ModelBundle/EventListener/GeneratePathListener.php
+++ b/ModelBundle/EventListener/GeneratePathListener.php
@@ -54,7 +54,7 @@ class GeneratePathListener implements ContainerAwareInterface
     public function setPath(LifecycleEventArgs $eventArgs)
     {
         $document = $eventArgs->getDocument();
-        if ($document instanceof NodeInterface) {
+        if ($document instanceof NodeInterface && false === $document->isDeleted()) {
             $nodeRepository = $this->container->get('open_orchestra_model.repository.node');
             $nodeId = $document->getNodeId();
             $siteId = $document->getSiteId();

--- a/ModelBundle/Repository/TrashItemRepository.php
+++ b/ModelBundle/Repository/TrashItemRepository.php
@@ -2,6 +2,7 @@
 
 namespace OpenOrchestra\ModelBundle\Repository;
 
+use OpenOrchestra\ModelInterface\Model\TrashItemInterface;
 use OpenOrchestra\ModelInterface\Repository\TrashItemRepositoryInterface;
 use OpenOrchestra\Pagination\MongoTrait\PaginationTrait;
 use OpenOrchestra\Repository\AbstractAggregateRepository;
@@ -12,4 +13,14 @@ use OpenOrchestra\Repository\AbstractAggregateRepository;
 class TrashItemRepository extends AbstractAggregateRepository implements TrashItemRepositoryInterface
 {
     use PaginationTrait;
+
+    /**
+     * @param $entityId
+     *
+     * @return TrashItemInterface
+     */
+    public function findByEntity($entityId)
+    {
+        return $this->findOneBy(array('entity.$id' => new \MongoId($entityId)));
+    }
 }

--- a/ModelBundle/Tests/EventListener/GeneratePathListenerTest.php
+++ b/ModelBundle/Tests/EventListener/GeneratePathListenerTest.php
@@ -3,6 +3,7 @@
 namespace OpenOrchestra\BackofficeBundle\Tests\EventListener;
 
 use OpenOrchestra\BaseBundle\Tests\AbstractTest\AbstractBaseTestCase;
+use OpenOrchestra\ModelInterface\Model\NodeInterface;
 use Phake;
 use OpenOrchestra\ModelBundle\EventListener\GeneratePathListener;
 use OpenOrchestra\ModelBundle\Document\Node;
@@ -104,13 +105,16 @@ class GeneratePathListenerTest extends AbstractBaseTestCase
         $node0 = Phake::mock('OpenOrchestra\ModelBundle\Document\Node');
         Phake::when($node0)->getNodeId()->thenReturn('fakeId');
         Phake::when($node0)->getPath()->thenReturn('fakeParentPath/fakePastId');
+        Phake::when($node0)->isDeleted()->thenReturn(false);
 
         $parentNode0 = Phake::mock('OpenOrchestra\ModelBundle\Document\Node');
         Phake::when($parentNode0)->getPath()->thenReturn('fakePath');
         Phake::when($parentNode0)->getPath()->thenReturn('fakeParentPath');
+        Phake::when($parentNode0)->isDeleted()->thenReturn(false);
 
         $child0_0 = Phake::mock('OpenOrchestra\ModelBundle\Document\Node');
         Phake::when($child0_0)->getPath()->thenReturn('fakeParentPath/fakePastId/fakeChild0Id');
+        Phake::when($child0_0)->isDeleted()->thenReturn(false);
 
         $children0 = new ArrayCollection();
         $children0->add($child0_0);
@@ -118,13 +122,16 @@ class GeneratePathListenerTest extends AbstractBaseTestCase
         $node1 = Phake::mock('OpenOrchestra\ModelBundle\Document\Node');
         Phake::when($node1)->getNodeId()->thenReturn('fakeId');
         Phake::when($node1)->getPath()->thenReturn('fakeParentPath/fakePastId');
+        Phake::when($node1)->isDeleted()->thenReturn(false);
 
         $parentNode1 = Phake::mock('OpenOrchestra\ModelBundle\Document\Node');
         Phake::when($parentNode1)->getPath()->thenReturn('fakePath');
         Phake::when($parentNode1)->getPath()->thenReturn('fakeParentPath');
+        Phake::when($parentNode1)->isDeleted()->thenReturn(false);
 
         $child1_0 = Phake::mock('OpenOrchestra\ModelBundle\Document\Node');
         Phake::when($child1_0)->getPath()->thenReturn('fakeParentPath/fakePastId/fakeChild0Id');
+        Phake::when($child1_0)->isDeleted()->thenReturn(false);
 
         $children1 = new ArrayCollection();
         $children1->add($child1_0);
@@ -134,6 +141,19 @@ class GeneratePathListenerTest extends AbstractBaseTestCase
             array('prePersist', $node0, $parentNode0, $children0, array('fakeParentPath/fakeId', 'fakeParentPath/fakeId/fakeChild0Id')),
             array('preUpdate', $node1, $parentNode1, $children1, array('fakeParentPath/fakeId', 'fakeParentPath/fakeId/fakeChild0Id'))
         );
+    }
+
+    /**
+     * Test no update path if node is deleted
+     */
+    public function testWithDeleteNode()
+    {
+        $node = Phake::mock('OpenOrchestra\ModelInterface\Model\NodeInterface');
+        Phake::when($this->lifecycleEventArgs)->getDocument()->thenReturn($node);
+
+        $this->listener->prePersist($this->lifecycleEventArgs);
+
+        Phake::verify($node, Phake::never())->setPath(Phake::anyParameters());
     }
 
     /**


### PR DESCRIPTION
[OO-BUGFIX] Path on node is updated only if node isn't deleted
[OO-BCBREAK] The `TrashItem` document has a new property `type`

https://github.com/open-orchestra/open-orchestra-cms-bundle/pull/1539
https://github.com/open-orchestra/open-orchestra-base-api-bundle/pull/76
https://github.com/open-orchestra/open-orchestra-media-admin-bundle/pull/189
https://github.com/open-orchestra/open-orchestra-model-interface/pull/172
https://github.com/open-orchestra/open-orchestra-model-bundle/pull/541