### PR TITLE
Update method has other node with same parent and order

### DIFF
--- a/ModelBundle/Repository/NodeRepository.php
+++ b/ModelBundle/Repository/NodeRepository.php
@@ -882,11 +882,11 @@ class NodeRepository extends AbstractAggregateRepository implements FieldAutoGen
                 'parentId' => $parentId,
                 'order'    => $order,
                 'nodeId'   => array('$ne' => $nodeId),
-                'deleted'  => false
+                'deleted'  => false,
+                'nodeType' => NodeInterface::TYPE_DEFAULT
             )
         );
         $node = $this->singleHydrateAggregateQuery($qa);
-
         return $node instanceof NodeInterface;
     }
 

--- a/ModelBundle/Tests/Functional/Repository/NodeRepositoryTest.php
+++ b/ModelBundle/Tests/Functional/Repository/NodeRepositoryTest.php
@@ -541,9 +541,10 @@ class NodeRepositoryTest extends AbstractKernelTestCase
     {
         return array(
             array(NodeInterface::ROOT_NODE_ID, 10, 'fixture_page_contact', true),
-            array(NodeInterface::ROOT_NODE_ID, 0, 'fixture_page_contact', true),
+            array(NodeInterface::ROOT_NODE_ID, 0, 'fixture_page_contact', false),
             array('fixture_page_legal_mentions', 0, 'fakeID', false),
             array(NodeInterface::ROOT_NODE_ID, 0, 'fakeID', false, '3'),
+            array(NodeInterface::TRANSVERSE_NODE_ID, 1, '-', false,),
         );
     }
 


### PR DESCRIPTION
[OO-BUGFIX]  method ``hasOtherNodeWithSameParentAndOrder```of ``NodeRepository`` check only on default nodes

https://github.com/open-orchestra/open-orchestra-cms-bundle/pull/1549
https://github.com/open-orchestra/open-orchestra-model-bundle/pull/545