### PR TITLE
Node and Site models now manage themselves metakeywords + metadescriptions

### DIFF
--- a/ModelBundle/Document/Node.php
+++ b/ModelBundle/Document/Node.php
@@ -196,6 +196,20 @@ class Node implements NodeInterface
     protected $routePattern;
 
     /**
+     * @var string $metaKeywords
+     *
+     * @ODM\Field(type="string")
+     */
+    protected $metaKeywords;
+
+    /**
+     * @var string $metaDescription
+     *
+     * @ODM\Field(type="string")
+     */
+    protected $metaDescription;
+
+    /**
      * Constructor
      */
     public function __construct()
@@ -677,5 +691,37 @@ class Node implements NodeInterface
     {
         $this->areas = new ArrayCollection();
         $this->blocks = new ArrayCollection();
+    }
+
+    /**
+     * @param string $metaKeywords
+     */
+    public function setMetaKeywords($metaKeywords)
+    {
+        $this->metaKeywords = $metaKeywords;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMetaKeywords()
+    {
+        return $this->metaKeywords;
+    }
+
+    /**
+     * @param string $metaDescription
+     */
+    public function setMetaDescription($metaDescription)
+    {
+        $this->metaDescription = $metaDescription;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMetaDescription()
+    {
+        return $this->metaDescription;
     }
 }

--- a/ModelBundle/Document/Site.php
+++ b/ModelBundle/Document/Site.php
@@ -64,6 +64,20 @@ class Site implements SiteInterface
     protected $theme;
 
     /**
+     * @var string $metaKeywords
+     *
+     * @ODM\Field(type="hash")
+     */
+    protected $metaKeywords;
+
+    /**
+     * @var string $metaDescriptions
+     *
+     * @ODM\Field(type="hash")
+     */
+    protected $metaDescriptions;
+
+    /**
      * @var string $robotsTxt
      *
      * @ODM\Field(type="string")
@@ -190,6 +204,116 @@ class Site implements SiteInterface
     public function getTheme()
     {
         return $this->theme;
+    }
+
+    /**
+     * @param array $metaKeywords
+     */
+    public function setMetaKeywords(array $metaKeywords)
+    {
+        $this->metaKeywords = array();
+
+        foreach ($metaKeywords as $language => $keywords) {
+            $this->addMetaKeywords($language, $keywords);
+        }
+    }
+
+    /**
+     * @param string $language
+     * @param string $metaKeywords
+     */
+    public function addMetaKeywords($language, $metaKeywords)
+    {
+        if (\is_string($language) && \is_string($metaKeywords)) {
+            $this->metaKeywords[$language] = $metaKeywords;
+        }
+    }
+
+    /**
+     * @param string $language
+     */
+    public function removeMetaKeywords($language)
+    {
+        if (\is_string($language) && isset($this->metaKeywords[$language])) {
+            unset($this->metaKeywords[$language]);
+        }
+    }
+
+    /**
+     * @return string
+     */
+    public function getMetaKeywords()
+    {
+        return $this->metaKeywords;
+    }
+
+    /**
+     * @param string $language
+     *
+     * @return string
+     */
+    public function getMetaKeywordsInLanguage($language)
+    {
+        if (isset($this->metaKeywords[$language])) {
+            return $this->metaKeywords[$language];
+        }
+
+        return '';
+    }
+
+    /**
+     * @param array $metaDescriptions
+     */
+    public function setMetaDescriptions(array $metaDescriptions)
+    {
+        $this->metaDescriptions = array();
+
+        foreach ($metaDescriptions as $language => $description) {
+            $this->addMetaDescription($language, $description);
+        }
+    }
+
+    /**
+     * @param string $language
+     * @param string $metaDescription
+     */
+    public function addMetaDescription($language, $metaDescription)
+    {
+        if (\is_string($language) && \is_string($metaDescription)) {
+            $this->metaDescriptions[$language] = $metaDescription;
+        }
+    }
+
+    /**
+     * @param string $language
+     */
+    public function removeMetaDescription($language)
+    {
+        if (\is_string($language) && isset($this->metaDescriptions[$language])) {
+            unset($this->metaDescriptions[$language]);
+        }
+    }
+
+    /**
+     * @return string
+     */
+    public function getMetaDescriptions()
+    {
+        return $this->metaDescriptions;
+    }
+
+    /**
+     * @param string $language
+     *
+     * @return string
+     */
+    public function getMetaDescriptionInLanguage($language)
+    {
+        if (isset($this->metaDescriptions[$language])) {
+            return $this->metaDescriptions[$language];
+        }
+
+        return '';
     }
 
     /**


### PR DESCRIPTION
[OO-MISC] Node and Site models now manage themselves metakeywords and metadescriptions
https://github.com/open-orchestra/open-orchestra-model-interface/pull/195
https://github.com/open-orchestra/open-orchestra-mongo-libs/pull/33
https://github.com/open-orchestra/open-orchestra-model-bundle/pull/595
https://github.com/open-orchestra/open-orchestra-cms-bundle/pull/1757
https://github.com/open-orchestra/open-orchestra-front-bundle/pull/171