### PR TITLE
1.1 fix content pagination count

### DIFF
--- a/ModelBundle/DataFixtures/MongoDB/LoadContentNewsData.php
+++ b/ModelBundle/DataFixtures/MongoDB/LoadContentNewsData.php
@@ -124,6 +124,7 @@ class LoadContentNewsData extends AbstractFixture implements OrderedFixtureInter
         $end = $this->generateContentAttribute('publish_end', '2014-12-19', 'date');
         $welcome = $this->generateContent('news', 'welcome', 'Welcome', 'fr');
         $welcome->addKeyword(EmbedKeyword::createFromKeyword($this->getReference('keyword-sit')));
+        $welcome->setLinkedToSite(true);
 
         return $this->addNewsAttributes($welcome, $title, $start, $end, $intro, $text);
     }

--- a/ModelBundle/Repository/ContentRepository.php
+++ b/ModelBundle/Repository/ContentRepository.php
@@ -369,27 +369,14 @@ class ContentRepository extends AbstractAggregateRepository implements FieldAuto
     }
 
     /**
-     * @param null                $contentType
+     * @param string|null         $contentType
      * @param FinderConfiguration $configuration
      * @param int|null            $siteId
      *
      * @return int
-     *
-     * @deprecated will be removed in 1.3.0, use countByContentTypeAndSiteInLastVersionWithFilter
      */
-    public function countByContentTypeInLastVersionWithFilter($contentType = null, FinderConfiguration $configuration = null, $siteId = null)
-    {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 1.1.3 and will be removed in 1.3.0. Use the '.__CLASS__.'::countByContentTypeAndSiteInLastVersionWithFilter method instead.', E_USER_DEPRECATED);
-
-        return $this->countByContentTypeAndSiteInLastVersionWithFilter($contentType, $configuration, $siteId);
-    }
-
-    /**
-     * {@inheritDoc}
-     * @see \OpenOrchestra\ModelInterface\Repository\ContentRepositoryInterface::countByContentTypeAndSiteInLastVersionWithFilter()
-     */
-    public function countByContentTypeAndSiteInLastVersionWithFilter(
-        $contentType = null,
+    public function countByContentTypeInLastVersionWithFilter(
+        $contentType,
         FinderConfiguration $configuration = null,
         $siteId = null
     ) {
@@ -409,11 +396,11 @@ class ContentRepository extends AbstractAggregateRepository implements FieldAuto
      *
      * @return int
      *
-     * @deprecated will be removed in 1.3.0, use countByContentTypeAndSiteInLastVersion
+     * @deprecated will be removed in 2.0, use countByContentTypeAndSiteInLastVersion
      */
     public function countByContentTypeInLastVersion($contentType = null)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 1.1.3 and will be removed in 1.3.0. Use the '.__CLASS__.'::countByContentTypeAndSiteInLastVersion method instead.', E_USER_DEPRECATED);
+        @trigger_error('The '.__METHOD__.' method is deprecated since version 1.1.3 and will be removed in 2.0. Use the '.__CLASS__.'::countByContentTypeAndSiteInLastVersion method instead.', E_USER_DEPRECATED);
 
         $qa = $this->createAggregateQueryWithContentTypeFilter($contentType);
         $qa->match($this->generateDeletedFilter());
@@ -424,10 +411,12 @@ class ContentRepository extends AbstractAggregateRepository implements FieldAuto
     }
 
     /**
-     * {@inheritDoc}
-     * @see \OpenOrchestra\ModelInterface\Repository\ContentRepositoryInterface::countByContentTypeAndSiteInLastVersion()
+     * @param string      $contentType
+     * @param string|null $siteId
+     *
+     * @return int
      */
-    public function countByContentTypeAndSiteInLastVersion($contentType = null, $siteId = null)
+    public function countByContentTypeAndSiteInLastVersion($contentType, $siteId = null)
     {
         $qa = $this->createAggregateQueryWithContentTypeFilter($contentType);
         $qa->match($this->generateDeletedFilter());

--- a/ModelBundle/Repository/ContentRepository.php
+++ b/ModelBundle/Repository/ContentRepository.php
@@ -374,32 +374,68 @@ class ContentRepository extends AbstractAggregateRepository implements FieldAuto
      * @param int|null            $siteId
      *
      * @return int
+     *
+     * @deprecated will be removed in 1.3.0, use countByContentTypeAndSiteInLastVersionWithFilter
      */
     public function countByContentTypeInLastVersionWithFilter($contentType = null, FinderConfiguration $configuration = null, $siteId = null)
     {
+        @trigger_error('The '.__METHOD__.' method is deprecated since version 1.1.3 and will be removed in 1.3.0. Use the '.__CLASS__.'::countByContentTypeAndSiteInLastVersionWithFilter method instead.', E_USER_DEPRECATED);
+
+        return $this->countByContentTypeAndSiteInLastVersionWithFilter($contentType, $configuration, $siteId);
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \OpenOrchestra\ModelInterface\Repository\ContentRepositoryInterface::countByContentTypeAndSiteInLastVersionWithFilter()
+     */
+    public function countByContentTypeAndSiteInLastVersionWithFilter(
+        $contentType = null,
+        FinderConfiguration $configuration = null,
+        $siteId = null
+    ) {
         $qa = $this->createAggregateQueryWithContentTypeFilter($contentType);
         $qa = $this->generateFilter($qa, $configuration);
         $qa->match($this->generateDeletedFilter());
         if (!is_null($siteId)) {
             $qa->match($this->generateSiteIdAndNotLinkedFilter($siteId));
         }
-        $elementName = 'content';
-        $this->generateLastVersionFilter($qa, $elementName);
+        $this->generateLastVersionFilter($qa, 'content');
 
-        return $this->countDocumentAggregateQuery($qa, $elementName);
+        return $this->countDocumentAggregateQuery($qa);
     }
 
     /**
      * @param string|null $contentType
      *
      * @return int
+     *
+     * @deprecated will be removed in 1.3.0, use countByContentTypeAndSiteInLastVersion
      */
     public function countByContentTypeInLastVersion($contentType = null)
     {
+        @trigger_error('The '.__METHOD__.' method is deprecated since version 1.1.3 and will be removed in 1.3.0. Use the '.__CLASS__.'::countByContentTypeAndSiteInLastVersion method instead.', E_USER_DEPRECATED);
+
         $qa = $this->createAggregateQueryWithContentTypeFilter($contentType);
         $qa->match($this->generateDeletedFilter());
         $elementName = 'content';
         $this->generateLastVersionFilter($qa, $elementName);
+
+        return $this->countDocumentAggregateQuery($qa);
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \OpenOrchestra\ModelInterface\Repository\ContentRepositoryInterface::countByContentTypeAndSiteInLastVersion()
+     */
+    public function countByContentTypeAndSiteInLastVersion($contentType = null, $siteId = null)
+    {
+        $qa = $this->createAggregateQueryWithContentTypeFilter($contentType);
+        $qa->match($this->generateDeletedFilter());
+        if (!is_null($siteId)) {
+            $qa->match($this->generateSiteIdAndNotLinkedFilter($siteId));
+        }
+
+        $this->generateLastVersionFilter($qa, 'content');
 
         return $this->countDocumentAggregateQuery($qa);
     }

--- a/ModelBundle/Tests/Functional/Repository/ContentRepositoryTest.php
+++ b/ModelBundle/Tests/Functional/Repository/ContentRepositoryTest.php
@@ -313,9 +313,13 @@ class ContentRepositoryTest extends AbstractKernelTestCase
      * @param integer $count
      *
      * @dataProvider provideContentTypeCount
+     *
+     * @deprecated will be removed in 2.0, use countByContentTypeAndSiteInLastVersion
      */
     public function testCountByContentTypeInLastVersion($contentType, $count)
     {
+        @trigger_error('The '.__METHOD__.' method is deprecated since version 1.1.3 and will be removed in 2.0. Use the '.__CLASS__.'::countByContentTypeAndSiteInLastVersion method instead.', E_USER_DEPRECATED);
+
         $contents = $this->repository->countByContentTypeInLastVersion($contentType);
         $this->assertEquals($count, $contents);
     }
@@ -364,43 +368,12 @@ class ContentRepositoryTest extends AbstractKernelTestCase
      * @param string  $contentType
      * @param array   $descriptionEntity
      * @param string  $search
+     * @param string  $siteId
      * @param int     $count
      *
      * @dataProvider provideColumnsAndSearchAndCount
      */
-    public function testCountByContentTypeInLastVersionWithSearchFilter($contentType, $descriptionEntity, $search, $count)
-    {
-        $configuration = FinderConfiguration::generateFromVariable($descriptionEntity, $search);
-
-        $sites = $this->repository->countByContentTypeInLastVersionWithFilter($contentType, $configuration);
-        $this->assertEquals($count, $sites);
-    }
-
-    /**
-     * @return array
-     */
-    public function provideColumnsAndSearchAndCount()
-    {
-        $descriptionEntity = $this->getDescriptionColumnEntity();
-
-        return array(
-            array('car', $descriptionEntity, $this->generateColumnsProvider(array('name' => '206')), 1),
-            array('car', $descriptionEntity, $this->generateColumnsProvider(null, 'portes'), 2),
-            array('news', $descriptionEntity, $this->generateColumnsProvider(null, 'news'), 0),
-            array('news', $descriptionEntity, $this->generateColumnsProvider(null, 'lorem'), 1),
-        );
-    }
-
-    /**
-     * @param string $contentType
-     * @param array  $descriptionEntity
-     * @param string $search
-     * @param string $siteId
-     * @param int    $count
-     *
-     * @dataProvider provideCountByContentTypeAndSiteInLastVersionWithSearchFilter
-     */
-    public function testCountByContentTypeAndSiteInLastVersionWithSearchFilter(
+    public function testCountByContentTypeInLastVersionWithSearchFilter(
         $contentType,
         $descriptionEntity,
         $search,
@@ -416,7 +389,7 @@ class ContentRepositoryTest extends AbstractKernelTestCase
     /**
      * @return array
      */
-    public function provideCountByContentTypeAndSiteInLastVersionWithSearchFilter()
+    public function provideColumnsAndSearchAndCount()
     {
         $descriptionEntity = $this->getDescriptionColumnEntity();
 

--- a/ModelBundle/Tests/Functional/Repository/ContentRepositoryTest.php
+++ b/ModelBundle/Tests/Functional/Repository/ContentRepositoryTest.php
@@ -334,6 +334,34 @@ class ContentRepositoryTest extends AbstractKernelTestCase
 
     /**
      * @param string  $contentType
+     * @param string  $siteId
+     * @param integer $count
+     *
+     * @dataProvider provideCountByContentTypeAndSiteInLastVersion
+     */
+    public function testCountByContentTypeAndSiteInLastVersion($contentType, $siteId, $count)
+    {
+        $contents = $this->repository->countByContentTypeAndSiteInLastVersion($contentType, $siteId);
+        $this->assertEquals($count, $contents);
+    }
+
+    /**
+     * @return array
+     */
+    public function provideCountByContentTypeAndSiteInLastVersion()
+    {
+        return array(
+            array('car', '1', 2),
+            array('car', '2', 3),
+            array('customer', '1', 2),
+            array('customer', '2', 2),
+            array('news', '1', 3),
+            array('news', '2', 4),
+        );
+    }
+
+    /**
+     * @param string  $contentType
      * @param array   $descriptionEntity
      * @param string  $search
      * @param int     $count
@@ -360,6 +388,49 @@ class ContentRepositoryTest extends AbstractKernelTestCase
             array('car', $descriptionEntity, $this->generateColumnsProvider(null, 'portes'), 2),
             array('news', $descriptionEntity, $this->generateColumnsProvider(null, 'news'), 0),
             array('news', $descriptionEntity, $this->generateColumnsProvider(null, 'lorem'), 1),
+        );
+    }
+
+    /**
+     * @param string $contentType
+     * @param array  $descriptionEntity
+     * @param string $search
+     * @param string $siteId
+     * @param int    $count
+     *
+     * @dataProvider provideCountByContentTypeAndSiteInLastVersionWithSearchFilter
+     */
+    public function testCountByContentTypeAndSiteInLastVersionWithSearchFilter(
+        $contentType,
+        $descriptionEntity,
+        $search,
+        $siteId,
+        $count
+    ) {
+        $configuration = FinderConfiguration::generateFromVariable($descriptionEntity, $search);
+
+        $contents = $this->repository->countByContentTypeInLastVersionWithFilter($contentType, $configuration, $siteId);
+        $this->assertEquals($count, $contents);
+    }
+
+    /**
+     * @return array
+     */
+    public function provideCountByContentTypeAndSiteInLastVersionWithSearchFilter()
+    {
+        $descriptionEntity = $this->getDescriptionColumnEntity();
+
+        return array(
+            array('car', $descriptionEntity, $this->generateColumnsProvider(array('name' => '206')), '1', 1),
+            array('car', $descriptionEntity, $this->generateColumnsProvider(array('name' => '206')), '2', 1),
+            array('car', $descriptionEntity, $this->generateColumnsProvider(array('name' => 'DS 3')), '1', 0),
+            array('car', $descriptionEntity, $this->generateColumnsProvider(array('name' => 'DS 3')), '2', 1),
+            array('car', $descriptionEntity, $this->generateColumnsProvider(null, 'portes'), '1', 2),
+            array('car', $descriptionEntity, $this->generateColumnsProvider(null, 'portes'), '2', 2),
+            array('news', $descriptionEntity, $this->generateColumnsProvider(null, 'news'), '1', 0),
+            array('news', $descriptionEntity, $this->generateColumnsProvider(null, 'news'), '2', 0),
+            array('news', $descriptionEntity, $this->generateColumnsProvider(null, 'lorem'), '1', 1),
+            array('news', $descriptionEntity, $this->generateColumnsProvider(null, 'lorem'), '2', 1),
         );
     }
 


### PR DESCRIPTION
[OO-BUGFIX] Fix elements count in content pagination.
[OO-DEPRECATED] ContentRepository::countByContentTypeInLastVersion method is deprecated since version 1.1.3 and will be removed in 2.0, it is replace by ContentRepository::countByContentTypeAndSiteInLastVersion method.

https://github.com/open-orchestra/open-orchestra-model-interface/pull/212
https://github.com/open-orchestra/open-orchestra-model-bundle/pull/621
https://github.com/open-orchestra/open-orchestra-cms-bundle/pull/1825