### PR TITLE
1.2 fix content pagination count

### DIFF
--- a/ModelBundle/DataFixtures/MongoDB/LoadContentNewsData.php
+++ b/ModelBundle/DataFixtures/MongoDB/LoadContentNewsData.php
@@ -123,6 +123,7 @@ class LoadContentNewsData extends AbstractFixture implements OrderedFixtureInter
         $end = $this->generateContentAttribute('publish_end', '2014-12-19', 'date');
         $welcome = $this->generateContent('news', 'welcome', 'Welcome', 'fr');
         $welcome->addKeyword($this->getReference('keyword-sit'));
+        $welcome->setLinkedToSite(true);
 
         return $this->addNewsAttributes($welcome, $title, $start, $end, $intro, $text);
     }

--- a/ModelBundle/Repository/ContentRepository.php
+++ b/ModelBundle/Repository/ContentRepository.php
@@ -282,38 +282,58 @@ class ContentRepository extends AbstractAggregateRepository implements FieldAuto
     }
 
     /**
-     * @param null                $contentType
+     * @param string|null         $contentType
      * @param FinderConfiguration $configuration
      * @param int|null            $siteId
      *
      * @return int
      */
-    public function countByContentTypeInLastVersionWithFilter($contentType = null, FinderConfiguration $configuration = null, $siteId = null)
-    {
+    public function countByContentTypeInLastVersionWithFilter(
+        $contentType,
+        FinderConfiguration $configuration = null,
+        $siteId = null
+    ) {
         $qa = $this->createAggregateQueryWithContentTypeFilter($contentType);
         $qa = $this->generateFilter($qa, $configuration);
         $qa->match($this->generateDeletedFilter());
         if (!is_null($siteId)) {
             $qa->match($this->generateSiteIdAndNotLinkedFilter($siteId));
         }
-        $elementName = 'content';
-        $this->generateLastVersionFilter($qa, $elementName);
-
-        return $this->countDocumentAggregateQuery($qa, $elementName);
+        $this->generateLastVersionFilter($qa, 'content');
+        return $this->countDocumentAggregateQuery($qa);
     }
 
     /**
      * @param string|null $contentType
      *
      * @return int
+     *
+     * @deprecated will be removed in 2.0, use countByContentTypeAndSiteInLastVersion
      */
     public function countByContentTypeInLastVersion($contentType = null)
     {
+        @trigger_error('The '.__METHOD__.' method is deprecated since version 1.1.3 and will be removed in 2.0. Use the '.__CLASS__.'::countByContentTypeAndSiteInLastVersion method instead.', E_USER_DEPRECATED);
         $qa = $this->createAggregateQueryWithContentTypeFilter($contentType);
         $qa->match($this->generateDeletedFilter());
         $elementName = 'content';
         $this->generateLastVersionFilter($qa, $elementName);
+        return $this->countDocumentAggregateQuery($qa);
+    }
 
+    /**
+     * @param string      $contentType
+     * @param string|null $siteId
+     *
+     * @return int
+     */
+    public function countByContentTypeAndSiteInLastVersion($contentType, $siteId = null)
+    {
+        $qa = $this->createAggregateQueryWithContentTypeFilter($contentType);
+        $qa->match($this->generateDeletedFilter());
+        if (!is_null($siteId)) {
+            $qa->match($this->generateSiteIdAndNotLinkedFilter($siteId));
+        }
+        $this->generateLastVersionFilter($qa, 'content');
         return $this->countDocumentAggregateQuery($qa);
     }
 


### PR DESCRIPTION
[OO-BUGFIX] Fix elements count in content pagination.
[OO-DEPRECATED] ContentRepositoryInterface::countByContentTypeInLastVersion method is deprecated since version 1.1.3 and will be removed in 2.0, it is replace by ContentRepository::countByContentTypeAndSiteInLastVersion method.

cherry-pick https://github.com/open-orchestra/open-orchestra-model-bundle/pull/621

https://github.com/open-orchestra/open-orchestra-model-bundle/pull/623
https://github.com/open-orchestra/open-orchestra-model-interface/pull/213
https://github.com/open-orchestra/open-orchestra-cms-bundle/pull/1829
https://github.com/open-orchestra/open-orchestra/pull/1001